### PR TITLE
feat: add CLI args passthrough with `--` separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,75 @@ tasks:
       {% for dep in self["dependencies"] %} gcc -c {{dep}} {% endfor %}
 ```
 
+## CLI Arguments Passthrough
+
+You can pass arguments directly to task commands using the `--` separator:
+
+```bash
+hace spec -- --verbose --tag=fast
+```
+
+Arguments after `--` are available in your Hacefile as template variables:
+
+- `{{CLI_ARGS}}` - Shell-quoted string of all passthrough arguments
+- `{{CLI_ARGS_LIST}}` - Array for Jinja iteration
+
+### Explicit Usage
+
+Place `{{CLI_ARGS}}` where you want the arguments to appear:
+
+```yaml
+tasks:
+  spec:
+    phony: true
+    commands: |
+      crystal spec {{CLI_ARGS}}
+```
+
+Running `hace spec -- --verbose` executes: `crystal spec --verbose`
+
+### Iterating Over Arguments
+
+Use `{{CLI_ARGS_LIST}}` with Jinja loops:
+
+```yaml
+tasks:
+  test-each:
+    phony: true
+    commands: |
+      {% for arg in CLI_ARGS_LIST %}
+      echo "Testing with: {{arg}}"
+      crystal spec {{arg}}
+      {% endfor %}
+```
+
+### Auto-Append Behavior
+
+If your commands don't use `{{CLI_ARGS}}` explicitly, passthrough arguments
+are automatically appended to the last command:
+
+```yaml
+tasks:
+  spec:
+    phony: true
+    commands: |
+      echo "Running tests..."
+      crystal spec
+```
+
+Running `hace spec -- --verbose` executes:
+1. `echo "Running tests..."`
+2. `crystal spec --verbose` (arguments auto-appended to last command)
+
+### Shell Quoting
+
+Arguments containing spaces or special characters are automatically shell-quoted:
+
+```bash
+hace spec -- "--tag=slow test"
+# Becomes: crystal spec '--tag=slow test'
+```
+
 ## Development
 
 See [TODO.md](TODO.md) for a list of things that are not done yet,

--- a/spec/cli_args_spec.cr
+++ b/spec/cli_args_spec.cr
@@ -1,0 +1,133 @@
+require "./spec_helper"
+include Hace
+
+def with_scenario(name, keep = [] of String, logs : IO::Memory = IO::Memory.new, &)
+  Log.setup(:debug, Log::IOBackend.new(io: logs, formatter: Log::ShortFormat))
+  Dir.cd("spec/testcases/#{name}") do
+    File.delete?(".croupier") unless keep.includes? ".croupier"
+    Dir.glob("*").each do |f|
+      next if f == "Hacefile.yml" || keep.includes?(f)
+      if File.directory?(f)
+        FileUtils.rm_rf(f)
+      else
+        File.delete?(f)
+      end
+    end
+    TaskManager.cleanup
+    yield
+  end
+end
+
+describe "CLI Args Passthrough" do
+  describe "explicit {{CLI_ARGS}}" do
+    it "should replace template with shell-quoted args" do
+      with_scenario("cli_args") do
+        HaceFile.run(arguments: ["explicit"], cli_args: ["--verbose", "--tag=fast"])
+        File.read("explicit.txt").strip.should eq "Args: --verbose --tag=fast"
+      end
+    end
+
+    it "should handle empty CLI_ARGS" do
+      with_scenario("cli_args") do
+        HaceFile.run(arguments: ["empty_args"], cli_args: [] of String)
+        File.read("empty.txt").strip.should eq "No args: ''"
+      end
+    end
+  end
+
+  describe "{{CLI_ARGS_LIST}}" do
+    it "should be iterable in Jinja" do
+      with_scenario("cli_args") do
+        HaceFile.run(arguments: ["list_form"], cli_args: ["--a", "--b"])
+        content = File.read("list.txt")
+        content.should contain "Count: 2"
+        content.should contain "- --a"
+        content.should contain "- --b"
+      end
+    end
+
+    it "should handle empty list" do
+      with_scenario("cli_args") do
+        HaceFile.run(arguments: ["list_form"], cli_args: [] of String)
+        content = File.read("list.txt")
+        content.should contain "Count: 0"
+      end
+    end
+  end
+
+  describe "auto-append behavior" do
+    it "should append to last command when no explicit usage" do
+      with_scenario("cli_args") do
+        HaceFile.run(arguments: ["auto_append"], cli_args: ["--verbose"])
+        content = File.read("auto.txt")
+        # Last command "echo crystal spec" should have --verbose appended
+        content.should contain "crystal spec --verbose"
+      end
+    end
+
+    it "should not append when CLI_ARGS is empty" do
+      with_scenario("cli_args") do
+        HaceFile.run(arguments: ["auto_append"], cli_args: [] of String)
+        content = File.read("auto.txt")
+        # Should not have trailing space or args
+        content.strip.should eq "Starting\ncrystal spec"
+      end
+    end
+
+    it "should append only to the last command in multi-command tasks" do
+      with_scenario("cli_args") do
+        HaceFile.run(arguments: ["multi_cmd"], cli_args: ["--flag"])
+        content = File.read("multi.txt")
+        # Only the last command should have --flag appended
+        content.should contain "Step 1"
+        content.should contain "Step 2"
+        content.should contain "Final step --flag"
+      end
+    end
+  end
+
+  describe "explicit placement" do
+    it "should place CLI_ARGS where specified" do
+      with_scenario("cli_args") do
+        HaceFile.run(arguments: ["middle"], cli_args: ["--verbose"])
+        content = File.read("middle.txt")
+        content.should contain "Before"
+        content.should contain "crystal spec --verbose"
+        content.should contain "After"
+      end
+    end
+
+    it "should not auto-append when explicit CLI_ARGS is used" do
+      with_scenario("cli_args") do
+        HaceFile.run(arguments: ["explicit"], cli_args: ["--verbose"])
+        content = File.read("explicit.txt")
+        # Should only appear where explicitly placed
+        content.strip.should eq "Args: --verbose"
+      end
+    end
+  end
+
+  describe "shell quoting" do
+    it "should properly quote args with spaces" do
+      with_scenario("cli_args") do
+        HaceFile.run(arguments: ["explicit"], cli_args: ["--tag=slow test"])
+        content = File.read("explicit.txt")
+        # Should be properly quoted for shell
+        content.should contain "'--tag=slow test'"
+      end
+    end
+
+    it "should properly quote args with special characters" do
+      with_scenario("cli_args") do
+        # Use patterns that test quoting without shell variable expansion
+        # Note: $VAR in double-quoted echo will still expand, but *.cr glob won't
+        HaceFile.run(arguments: ["explicit"], cli_args: ["--pattern=*.cr", "--with-brackets=[test]"])
+        content = File.read("explicit.txt")
+        # Glob pattern should be quoted and not expanded
+        content.should contain "'--pattern=*.cr'"
+        # Brackets should be quoted
+        content.should contain "'--with-brackets=[test]'"
+      end
+    end
+  end
+end

--- a/spec/testcases/cli_args/.gitignore
+++ b/spec/testcases/cli_args/.gitignore
@@ -1,0 +1,2 @@
+*.txt
+.croupier

--- a/spec/testcases/cli_args/Hacefile.yml
+++ b/spec/testcases/cli_args/Hacefile.yml
@@ -1,0 +1,45 @@
+tasks:
+  # Test explicit {{CLI_ARGS}} usage
+  explicit:
+    phony: true
+    default: true
+    commands: |
+      echo "Args: {{CLI_ARGS}}" > explicit.txt
+
+  # Test {{CLI_ARGS_LIST}} iteration
+  list_form:
+    phony: true
+    commands: |
+      echo "Count: {{CLI_ARGS_LIST | length}}" > list.txt
+      {% for arg in CLI_ARGS_LIST %}
+      echo "  - {{arg}}" >> list.txt
+      {% endfor %}
+
+  # Test auto-append (no explicit usage)
+  auto_append:
+    phony: true
+    commands: |
+      echo "Starting" > auto.txt
+      echo "crystal spec" >> auto.txt
+
+  # Test middle placement with explicit CLI_ARGS
+  middle:
+    phony: true
+    commands: |
+      echo "Before" > middle.txt
+      echo "crystal spec {{CLI_ARGS}}" >> middle.txt
+      echo "After" >> middle.txt
+
+  # Test with multiple commands - auto-append to last only
+  multi_cmd:
+    phony: true
+    commands: |
+      echo "Step 1" > multi.txt
+      echo "Step 2" >> multi.txt
+      echo "Final step" >> multi.txt
+
+  # Test empty CLI_ARGS (no passthrough)
+  empty_args:
+    phony: true
+    commands: |
+      echo "No args: '{{CLI_ARGS}}'" > empty.txt

--- a/src/hace.cr
+++ b/src/hace.cr
@@ -109,10 +109,7 @@ module Hace
           next unless commands
 
           cmd_str = commands.as_s
-          if cmd_str.includes?("{{CLI_ARGS}}") ||
-             cmd_str.includes?("{{ CLI_ARGS }}") ||
-             cmd_str.includes?("{{CLI_ARGS_LIST}}") ||
-             cmd_str.includes?("{{ CLI_ARGS_LIST }}")
+          if cmd_str.matches?(/\{\{\s*CLI_ARGS(_LIST)?\s*\}\}/)
             Hace::TASKS_WITH_CLI_ARGS.add(name.as_s)
             Log.debug { "detect_cli_args_usage: task '#{name}' uses CLI_ARGS" }
           end

--- a/src/hace.cr
+++ b/src/hace.cr
@@ -11,7 +11,21 @@ module Hace
   VARIABLES   = {} of String => YAML::Any
   ENVIRONMENT = {} of String => String
 
+  # Track which tasks explicitly use {{CLI_ARGS}} (detected before Crinja expansion)
+  TASKS_WITH_CLI_ARGS = Set(String).new
+
   extend self
+
+  # Inject CLI_ARGS and CLI_ARGS_LIST into VARIABLES for template expansion
+  def self.inject_cli_args(cli_args : Array(String))
+    # CLI_ARGS: shell-quoted string for direct shell usage
+    cli_args_string = cli_args.map { |arg| Process.quote(arg) }.join(" ")
+    VARIABLES["CLI_ARGS"] = YAML::Any.new(cli_args_string)
+
+    # CLI_ARGS_LIST: array for Jinja iteration
+    cli_args_list = cli_args.map { |arg| YAML::Any.new(arg) }
+    VARIABLES["CLI_ARGS_LIST"] = YAML::Any.new(cli_args_list)
+  end
 
   # This parses only env and variables, not tasks
   class PartialHaceFile
@@ -43,13 +57,19 @@ module Hace
         data = File.read(filename)
         p = Hace::PartialHaceFile.from_yaml(data)
 
-        rendered_data = data.split("\n").map do |line|
-          begin
-            Crinja.render(line, p.variables)
-          rescue
-            line
-          end
-        end.join("\n")
+        # Detect which tasks explicitly use CLI_ARGS BEFORE Crinja expansion
+        # This is needed because Crinja will replace {{CLI_ARGS}} with actual values
+        detect_cli_args_usage(data)
+
+        # Merge Hacefile variables with global VARIABLES (includes CLI_ARGS if already set)
+        render_context = p.variables.merge(Hace::VARIABLES)
+
+        # Render entire file at once to support multi-line Jinja control structures
+        rendered_data = begin
+          Crinja.render(data, render_context)
+        rescue
+          data
+        end
 
         f = Hace::HaceFile.from_yaml(rendered_data)
         ENV.each { |k, v| Hace::ENVIRONMENT[k] = v }
@@ -74,12 +94,41 @@ module Hace
       f
     end
 
+    # Detect which tasks explicitly use CLI_ARGS before Crinja expansion
+    # Parses raw YAML to find task commands containing {{CLI_ARGS}} patterns
+    private def self.detect_cli_args_usage(raw_data : String)
+      Hace::TASKS_WITH_CLI_ARGS.clear
+
+      begin
+        yaml = YAML.parse(raw_data)
+        tasks = yaml["tasks"]?
+        return unless tasks
+
+        tasks.as_h.each do |name, task|
+          commands = task["commands"]?
+          next unless commands
+
+          cmd_str = commands.as_s
+          if cmd_str.includes?("{{CLI_ARGS}}") ||
+             cmd_str.includes?("{{ CLI_ARGS }}") ||
+             cmd_str.includes?("{{CLI_ARGS_LIST}}") ||
+             cmd_str.includes?("{{ CLI_ARGS_LIST }}")
+            Hace::TASKS_WITH_CLI_ARGS.add(name.as_s)
+            Log.debug { "detect_cli_args_usage: task '#{name}' uses CLI_ARGS" }
+          end
+        end
+      rescue ex
+        Log.debug { "detect_cli_args_usage: error parsing YAML: #{ex}" }
+      end
+    end
+
     # Configuration structure for task execution
     private struct ExecutionSetup
       def initialize(
         @hacefile : HaceFile,
         @arguments : Array(String),
         @filename : String,
+        @cli_args : Array(String),
         @run_all : Bool,
         @dry_run : Bool,
         @question : Bool,
@@ -91,6 +140,7 @@ module Hace
       getter hacefile : HaceFile
       getter arguments : Array(String)
       getter filename : String
+      getter cli_args : Array(String)
       getter? run_all : Bool
       getter? dry_run : Bool
       getter? question : Bool
@@ -100,12 +150,16 @@ module Hace
       def self.from_arguments(
         arguments : Array(String),
         filename : String,
+        cli_args : Array(String),
         run_all : Bool,
         dry_run : Bool,
         question : Bool,
         keep_going : Bool,
         parallel : Bool,
       )
+        # Inject CLI_ARGS BEFORE loading (so they're available during task expansion)
+        Hace.inject_cli_args(cli_args)
+
         hacefile = HaceFile.load_file(filename)
 
         # Extract and apply variable assignments from arguments
@@ -120,6 +174,7 @@ module Hace
           hacefile: hacefile,
           arguments: arguments,
           filename: filename,
+          cli_args: cli_args,
           run_all: run_all,
           dry_run: dry_run,
           question: question,
@@ -146,6 +201,7 @@ module Hace
     def self.run(
       arguments = [] of String,
       filename = "Hacefile.yml",
+      cli_args = [] of String,
       run_all : Bool = false,
       dry_run : Bool = false,
       question : Bool = false,
@@ -155,6 +211,7 @@ module Hace
       setup = ExecutionSetup.from_arguments(
         arguments: arguments,
         filename: filename,
+        cli_args: cli_args,
         run_all: run_all,
         dry_run: dry_run,
         question: question,
@@ -277,8 +334,11 @@ module Hace
     def self.auto(
       arguments = [] of String,
       filename = "Hacefile.yml",
+      cli_args = [] of String,
     )
-      # TODO: implement the other flags and arguments
+      # Inject CLI_ARGS BEFORE loading (so they're available during task expansion)
+      Hace.inject_cli_args(cli_args)
+
       hacefile = load_file(filename)
       hacefile.gen_tasks
       begin
@@ -314,7 +374,7 @@ module Hace
     def to_hash
       # Yes, not pretty but this gives me the right types for merging
       # with variables, so I can use it in Crinja.render
-      YAML.parse(self.to_yaml).as_h
+      YAML.parse(to_yaml).as_h
     end
 
     # We want to support variables and environment variables also in things
@@ -322,14 +382,17 @@ module Hace
     #
     # Besides the global VARIABLES, they also have access to self
     def expand
-      variables = {"self" => self.to_hash}.merge Hace::VARIABLES
+      # Build variables hash maintaining proper types for Crinja
+      variables = Hace::VARIABLES.dup
+      variables["self"] = YAML.parse(to_yaml)
+
       @outputs = @outputs.map { |outp| Hace.expand_string(outp, variables) }
-      variables = {"self" => self.to_hash}.merge Hace::VARIABLES
+      variables["self"] = YAML.parse(to_yaml)
 
       # Dependencies expand both variables and globs
       @dependencies = @dependencies.map { |dep| Hace.expand_string(dep, variables) }
       @dependencies = @dependencies.flat_map { |dep| Hace.expand_glob(dep) }
-      variables = {"self" => self.to_hash}.merge Hace::VARIABLES
+      variables["self"] = YAML.parse(to_yaml)
       @commands = Hace.expand_string(@commands, variables)
     end
 
@@ -385,6 +448,20 @@ module Hace
 
               # Build combined shell script
               combined_script = commands.join("\n")
+
+              # Hybrid auto-append: if CLI_ARGS not explicitly used, append to last command
+              # Uses pre-Crinja detection from TASKS_WITH_CLI_ARGS set
+              uses_explicit_cli_args = Hace::TASKS_WITH_CLI_ARGS.includes?(name)
+              if !uses_explicit_cli_args
+                cli_args_list = Hace::VARIABLES["CLI_ARGS_LIST"]?.try(&.as_a?)
+                if cli_args_list && !cli_args_list.empty?
+                  quoted_args = cli_args_list.map { |arg| Process.quote(arg.as_s) }.join(" ")
+                  lines = combined_script.split("\n")
+                  lines[-1] = lines[-1] + " " + quoted_args
+                  combined_script = lines.join("\n")
+                  Log.debug { "Auto-appended CLI_ARGS to last command: #{quoted_args}" }
+                end
+              end
 
               # Log individual commands for debugging
               commands.each do |command|

--- a/src/main.cr
+++ b/src/main.cr
@@ -6,7 +6,7 @@ DOC = <<-DOC
 hace makes things, like make.
 
 Usage:
-  hace [options] [<task>...]
+  hace [options] [<task>...] [-- <args>...]
   hace --completion=<shell>
   hace --help
 
@@ -226,7 +226,11 @@ struct LogFormat < Log::StaticFormatter
 end
 
 begin
-  args = Docopt.docopt(DOC, argv: ARGV, version: "Hacé version #{Hace::VERSION}", help: true, exit: true)
+  # Split ARGV at -- separator for CLI args passthrough
+  dash_index = ARGV.index("--")
+  hace_args, passthrough_args = dash_index ? {ARGV[0...dash_index].to_a, ARGV[(dash_index + 1)..].to_a} : {ARGV.to_a, [] of String}
+
+  args = Docopt.docopt(DOC, argv: hace_args, version: "Hacé version #{Hace::VERSION}", help: true, exit: true)
 
   # Extract options from docopt result with safe casting
   quiet = args["--quiet"].as?(Bool) || false
@@ -305,6 +309,7 @@ begin
       Hace::HaceFile.auto(
         arguments: task_args,
         filename: file,
+        cli_args: passthrough_args,
       )
       Log.info { "Running in auto mode, press Ctrl+C to stop" }
       loop do
@@ -323,6 +328,7 @@ begin
     Hace::HaceFile.run(
       filename: file,
       arguments: task_args,
+      cli_args: passthrough_args,
       run_all: always_make,
       dry_run: dry_run,
       question: question,


### PR DESCRIPTION
Implement CLI argument passthrough using template variables:
- `{{CLI_ARGS}}` - shell-quoted string of all passthrough args
- `{{CLI_ARGS_LIST}}` - array for Jinja iteration
- Auto-append to last command when no explicit usage

Usage: `hace spec -- --verbose --tag=fast`

Resolves #1